### PR TITLE
Add didUpdateWidget to react to layout changes

### DIFF
--- a/lib/audio_wave.dart
+++ b/lib/audio_wave.dart
@@ -86,6 +86,13 @@ class _AudioWaveState extends State<AudioWave> {
       bars = widget.bars;
     }
   }
+  
+  @override
+  void didUpdateWidget(AudioWave oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    bars = widget.bars;
+    setState(() {});
+  }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
I encountered that if you change your device orientation from portrait to landscape or change your web browser size, that my dynamic generated bars aren't updated and cause layout errors (too much or too few bars).

In this package there was only missing to react to updates and get the actual bars from outside.